### PR TITLE
0005: add java11 for system.properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,6 @@ jobs:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
 
-      # run tests!
+      # run coding style check in main src and tests!
+      - run: gradle checkstyleMain
       - run: gradle test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
+[![CircleCI](https://circleci.com/gh/mountkingx/spring-mvc-blog/tree/main.svg?style=svg)](https://circleci.com/gh/mountkingx/spring-mvc-blog/tree/main)
+
 # spring-mvc-blog
 
 Spring MVC project for personal development blog
 
 - initialized with https://start.spring.io/
+- manually added checkstyle configuration
+- incorporated circleci support (.circleci/config)

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
Avoid error found in heroku deployment
```bash
remote:        Daemon will be stopped at the end of the build 
remote:        > Task :compileJava FAILED
remote:        
remote:        FAILURE: Build failed with an exception.
remote:        
remote:        * What went wrong:
remote:        Execution failed for task ':compileJava'.
remote:        > invalid source release: 11
```