### PR TITLE
0006: added circleci configs for Heroku auto-deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,3 +41,25 @@ jobs:
       # run coding style check in main src and tests!
       - run: gradle checkstyleMain
       - run: gradle test
+
+    deploy:
+      docker:
+        - image: circleci/openjdk:11-jdk
+      steps:
+        - checkout
+        - run:
+            name: Deploy Main branch to Heroku Main
+            command: |
+              git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build # only run deploy-via-git job if the build job has completed
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,15 +42,15 @@ jobs:
       - run: gradle checkstyleMain
       - run: gradle test
 
-    deploy:
-      docker:
-        - image: circleci/openjdk:11-jdk
-      steps:
-        - checkout
-        - run:
-            name: Deploy Main branch to Heroku Main
-            command: |
-              git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
+  deploy:
+    docker:
+      - image: circleci/openjdk:11-jdk
+    steps:
+      - checkout
+      - run:
+          name: Deploy Main branch to Heroku Main
+          command: |
+            git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
 
 workflows:
   version: 2


### PR DESCRIPTION
Added circleci configs for CD in Heroku
- HEROKU_API_KEY can be read from https://dashboard.heroku.com/account
- HEROKU_APP_NAME can be read from UI or command line of local-dev

Before merging, add these env variables to 
CircleCI's Project Settings/spring-mvc-blog